### PR TITLE
Support Redmine version string with multiple digits

### DIFF
--- a/app/controllers/api/v1/qangaroo_services_controller.rb
+++ b/app/controllers/api/v1/qangaroo_services_controller.rb
@@ -9,7 +9,7 @@ module Api
       respond_to :json
 
       def verify_qangaroo_plugin
-        @redmine_version = Redmine::Info.versioned_name.match(/(\d+\.\d+\.\d+)/)[1]
+        @redmine_version = Redmine::Info.versioned_name.slice(/\d+\.\d+\.\d+/)
         @plugin = Redmine::Plugin.find(:qangaroo_plugin)
         ssl = request.ssl? ? true : false
         if @plugin

--- a/app/controllers/api/v1/qangaroo_services_controller.rb
+++ b/app/controllers/api/v1/qangaroo_services_controller.rb
@@ -9,7 +9,7 @@ module Api
       respond_to :json
 
       def verify_qangaroo_plugin
-        @redmine_version = Redmine::Info.versioned_name.match(/(\d.\d.\d)/)[1]
+        @redmine_version = Redmine::Info.versioned_name.match(/(\d+\.\d+\.\d+)/)[1]
         @plugin = Redmine::Plugin.find(:qangaroo_plugin)
         ssl = request.ssl? ? true : false
         if @plugin


### PR DESCRIPTION
- Fixes the regexp in `Api::V1::QangarooServicesController#verify_qangaroo_plugin` to handle version string like `2.6.10` correctly. (dfab266)
- Replaces `match(regexp)[1]` with `slice(regexp)` to prevents `NoMethodError` on matching failure. (19c0eff)